### PR TITLE
Do not store tokens in authStr field

### DIFF
--- a/src/libopenid.cpp
+++ b/src/libopenid.cpp
@@ -916,12 +916,6 @@ irods::error openid_auth_client_request(
         }
         else {
             std::string original_sess = context_map[ irods::AUTH_PASSWORD_KEY ];
-            if ( session_token.size() > LONG_NAME_LEN ) {
-                throw std::runtime_error( "Session was too long: " + std::to_string( session_token.size() ) );
-            }
-
-            // copy it to the authStr field NAME_LEN=64
-            strncpy( _comm->clientUser.authInfo.authStr, session_token.c_str(), session_token.size() );
 
             if ( session_token.size() != 0 && session_token.compare( original_sess ) != 0 ) {
                 // server returned a new session token, because existing one is not valid


### PR DESCRIPTION
Based on the mail conversation, I am putting this fix up to a debate.

Full tokens should not be stored in the authStr field. Can cause problems with services like Keycloak, which return tokens way longer than 256 chars. 